### PR TITLE
[[QOLDEV-22] Introduce custom download folder and ensure it works in headless

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Get Versions
+        run: |
+          echo "Google chrome version"
+          google-chrome --version
+          echo "firefox version"
+          firefox --version
+          echo "temp folder: ${{ runner.temp }}"
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
@@ -18,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots verify
+        run: mvn --batch-mode --update-snapshots verify -Djava.io.tmpdir=${{ runner.temp }}
       - run: mkdir staging && cp target/*.jar staging
       - uses: actions/upload-artifact@v2
         with:

--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ Environment Args that you can use:
 
 ###Change log###
 
-Allow hand off without deleting cookies
-Allow browser reuse to be changed from default 10 to your preferred usage.
+* Allow hand off without deleting cookies
+* Allow browser reuse to be changed from default 10 to your preferred usage.
+* Allow download directory to be set on browser creation

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,13 @@
                 <exclusion><groupId>org.eclipse.jetty.websocket</groupId><artifactId>websocket-common</artifactId></exclusion>
                 <exclusion><groupId>org.eclipse.jetty.websocket</groupId><artifactId>websocket-api</artifactId></exclusion>
                 <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-io</artifactId></exclusion>
+                <exclusion><groupId>org.apache.httpcomponents.client5</groupId><artifactId>httpclient5</artifactId></exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
         </dependency>
 
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId><version>1.7.36</version></dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <url>https://nexus.tools.services.qld.gov.au/nexus/repository/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
-    
+
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
@@ -39,7 +39,7 @@
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <maven-pmd-plugin.version>3.16.0</maven-pmd-plugin.version>
-        <owasp.dependency-check-maven.version>7.1.0</owasp.dependency-check-maven.version>
+        <owasp.dependency-check-maven.version>8.1.2</owasp.dependency-check-maven.version>
 
 
         <qa.directory>${project.basedir}/src/qa</qa.directory>
@@ -75,23 +75,24 @@
 
     <dependencies>
         <!-- overrides of wdm docker features -->
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.13.2.2</version></dependency>
-        <dependency><groupId>org.bouncycastle</groupId><artifactId>bcprov-jdk15on</artifactId><version>1.70</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.14.2</version></dependency>
+        <dependency><groupId>org.bouncycastle</groupId><artifactId>bcprov-jdk15on</artifactId><version>1.69</version></dependency>
 
-        <dependency><groupId>io.github.bonigarcia</groupId><artifactId>webdrivermanager</artifactId><version>5.1.1</version>
-        <exclusions>
-            <exclusion><groupId>org.seleniumhq.selenium</groupId><artifactId>selenium-java</artifactId></exclusion>
-            <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
-            <exclusion><groupId>com.google.guava</groupId><artifactId>guava</artifactId></exclusion>
-            <exclusion><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></exclusion>
-            <exclusion><groupId>org.bouncycastle</groupId><artifactId>bcprov-jdk15on</artifactId></exclusion>
-            <exclusion><groupId>org.eclipse.jetty.websocket</groupId><artifactId>websocket-client</artifactId></exclusion>
-            <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-util</artifactId></exclusion>
-            <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-http</artifactId></exclusion>
-            <exclusion><groupId>org.eclipse.jetty.websocket</groupId><artifactId>websocket-common</artifactId></exclusion>
-            <exclusion><groupId>org.eclipse.jetty.websocket</groupId><artifactId>websocket-api</artifactId></exclusion>
-            <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-io</artifactId></exclusion>
-        </exclusions></dependency>
+        <dependency><groupId>io.github.bonigarcia</groupId><artifactId>webdrivermanager</artifactId><version>5.3.2</version>
+            <exclusions>
+                <exclusion><groupId>org.seleniumhq.selenium</groupId><artifactId>selenium-java</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>com.google.guava</groupId><artifactId>guava</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></exclusion>
+                <exclusion><groupId>org.bouncycastle</groupId><artifactId>bcprov-jdk15on</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty.websocket</groupId><artifactId>websocket-client</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-util</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-http</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty.websocket</groupId><artifactId>websocket-common</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty.websocket</groupId><artifactId>websocket-api</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-io</artifactId></exclusion>
+            </exclusions>
+        </dependency>
 
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>com.google.guava</groupId><artifactId>guava</artifactId><version>31.1-jre</version></dependency>
@@ -100,8 +101,8 @@
                 <exclusion><groupId>org.seleniumhq.selenium</groupId><artifactId>selenium-opera-driver</artifactId></exclusion>
                 <exclusion><groupId>com.google.guava</groupId><artifactId>guava</artifactId></exclusion></exclusions>
         </dependency>
-        <dependency><groupId>net.sourceforge.htmlunit</groupId><artifactId>htmlunit</artifactId><version>2.61.0</version></dependency>
-        <dependency><groupId>org.seleniumhq.selenium</groupId><artifactId>htmlunit-driver</artifactId><version>2.56.0</version>
+        <dependency><groupId>net.sourceforge.htmlunit</groupId><artifactId>htmlunit</artifactId><version>2.70.0</version></dependency>
+        <dependency><groupId>org.seleniumhq.selenium</groupId><artifactId>htmlunit-driver</artifactId><version>2.70.0</version>
             <exclusions><exclusion><groupId>net.sourceforge.htmlunit</groupId><artifactId>htmlunit</artifactId></exclusion></exclusions>
         </dependency>
         <dependency><scope>test</scope><groupId>junit</groupId><artifactId>junit</artifactId><version>4.13.2</version></dependency>
@@ -168,9 +169,6 @@
                 <!-- The path for the properties file to be generated. See Super Pom for default variable reference https://maven.apache.org/guides/introduction/introduction-to-the-pom.html -->
                 <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
             </configuration>
-        </plugin>
-        <plugin>
-            <groupId>org.jacoco</groupId><artifactId>jacoco-maven-plugin</artifactId>
         </plugin>
 
         <!--Set up to ignore integration tests-->

--- a/src/main/java/au/gov/qld/online/selenium/WebDriverHolder.java
+++ b/src/main/java/au/gov/qld/online/selenium/WebDriverHolder.java
@@ -7,10 +7,12 @@ public class WebDriverHolder {
     private WebDriver webDriver;
     private DriverTypes driverType;
     private int numberUsed = 0;
+    private String downloadDirectory;
 
-    public WebDriverHolder(WebDriver webDriver, DriverTypes driverType) {
+    public WebDriverHolder(WebDriver webDriver, DriverTypes driverType, String downloadDirectory) {
         this.webDriver = webDriver;
         this.driverType = driverType;
+        this.downloadDirectory = downloadDirectory;
     }
 
     public WebDriver getWebDriver() {
@@ -27,5 +29,9 @@ public class WebDriverHolder {
 
     public int incrementUsed() {
         return ++numberUsed;
+    }
+
+    public String getDownloadDirectory() {
+        return downloadDirectory;
     }
 }

--- a/src/qa/owasp-dependency-checker-suppressions.xml
+++ b/src/qa/owasp-dependency-checker-suppressions.xml
@@ -13,17 +13,16 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-   file name: htmlunit-cssparser-1.12.0.jar, regex for cve CVE-2020-5529 is htmlunit* which hits cssparser
+   file name: guava-30.1.1-jre.jar
+   Only vulnerable if using com.google.common.io.Files.createTempDir(), which does not appear to be in use and has been marked as deprecated in versions 30.0 and later
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/net\.sourceforge\.htmlunit/htmlunit\-cssparser@.*$</packageUrl>
-        <cpe>cpe:/a:htmlunit_project:htmlunit</cpe>
+        <cve>CVE-2020-8908</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-   file name: htmlunit-driver-2.56.0.jar
-   cve is for neko-htmlunit-driver and flags seleniumhq driver instead, so false positive
+   file names: okhttp-3.11.0.jar
+   False positive, this vulnerability is for google:android, which is not a dependency
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.seleniumhq\.selenium/htmlunit\-driver@.*$</packageUrl>
-        <cve>CVE-2022-29546</cve>
+        <cve>CVE-2021-0341</cve>
     </suppress>
 </suppressions>

--- a/src/qa/pmd-rules.xml
+++ b/src/qa/pmd-rules.xml
@@ -25,6 +25,7 @@
         <exclude name="DataflowAnomalyAnalysis"/>
         <exclude name="BeanMembersShouldSerialize"/>
         <exclude name="UseLocaleWithCaseConversions"/>
+        <exclude name="CloseResource"/>
     </rule>
     <!--<rule ref="category/java/multithreading.xml"></rule>-->
     <!--<rule ref="category/java/security.xml"></rule>-->

--- a/src/test/java/au/gov/qld/online/selenium/SeleniumHelperTest.java
+++ b/src/test/java/au/gov/qld/online/selenium/SeleniumHelperTest.java
@@ -1,8 +1,22 @@
 package au.gov.qld.online.selenium;
 
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.FluentWait;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,8 +38,9 @@ public class SeleniumHelperTest {
         String testName = new Object(){}.getClass().getEnclosingMethod().getName();
         SeleniumHelper.setDoScreenPrints(true);
         holder = SeleniumHelper.getWebDriver(DriverTypes.FIREFOX);
-        holder.getWebDriver().navigate().to("https://example2.com/");
+        holder.getWebDriver().navigate().to("https://google.com/");
         SeleniumHelper.performScreenPrint(holder, testName);
+        SeleniumHelper.close(holder);
     }
 
     @Test
@@ -34,7 +49,7 @@ public class SeleniumHelperTest {
         SeleniumHelper.setDoScreenPrints(true);
         holder = SeleniumHelper.getWebDriver(DriverTypes.FIREFOX);
         WebDriverHolder holder2 = SeleniumHelper.getWebDriver(DriverTypes.FIREFOX);
-        holder.getWebDriver().navigate().to("https://example2.com/");
+        holder.getWebDriver().navigate().to("https://google.com/");
         SeleniumHelper.performScreenPrint(holder2, testName);
         holder2.getWebDriver().navigate().to("https://www.qld.gov.au");
         SeleniumHelper.performScreenPrint(holder, testName);
@@ -55,7 +70,7 @@ public class SeleniumHelperTest {
         SeleniumHelper.setDoScreenPrints(true);
         holder = SeleniumHelper.getWebDriver(DriverTypes.FIREFOX);
         WebDriverHolder holder2 = SeleniumHelper.getWebDriver(DriverTypes.CHROME);
-        holder.getWebDriver().navigate().to("https://example2.com/");
+        holder.getWebDriver().navigate().to("https://google.com/");
         SeleniumHelper.performScreenPrint(holder2, testName);
         holder2.getWebDriver().navigate().to("https://www.qld.gov.au");
         SeleniumHelper.performScreenPrint(holder, testName);
@@ -75,10 +90,10 @@ public class SeleniumHelperTest {
         SeleniumHelper.setDoScreenPrints(true);
         try {
             holder = SeleniumHelper.getWebDriver(DriverTypes.EDGE);
-            holder.getWebDriver().navigate().to("https://example2.com/");
+            holder.getWebDriver().navigate().to("https://google.com/");
             SeleniumHelper.performScreenPrint(holder, testName);
         } catch (RuntimeException e) {
-            //expected when not on windows
+            // Expected when not on windows
             assertThat(e.getMessage()).isEqualTo("Have to be on windows to run Edge");
             assertThat(e).isInstanceOf(IllegalStateException.class);
         }
@@ -90,9 +105,10 @@ public class SeleniumHelperTest {
         SeleniumHelper.setDoScreenPrints(true);
         try {
             holder = SeleniumHelper.getWebDriver(DriverTypes.SAFARI);
-            holder.getWebDriver().navigate().to("https://example2.com/");
+            holder.getWebDriver().navigate().to("https://google.com/");
             SeleniumHelper.performScreenPrint(holder, testName);
         } catch (RuntimeException e) {
+            // Expected when not on mac
             assertThat(e.getMessage()).isEqualTo("Have to be on Mac to run Safari");
             assertThat(e).isInstanceOf(IllegalStateException.class);
         }
@@ -103,7 +119,7 @@ public class SeleniumHelperTest {
         String testName = new Object(){}.getClass().getEnclosingMethod().getName();
         SeleniumHelper.setDoScreenPrints(true);
         holder = SeleniumHelper.getWebDriver(DriverTypes.CHROME);
-        holder.getWebDriver().navigate().to("https://example2.com/");
+        holder.getWebDriver().navigate().to("https://google.com/");
         SeleniumHelper.performScreenPrint(holder, testName);
         SeleniumHelper.close(holder);
     }
@@ -113,7 +129,7 @@ public class SeleniumHelperTest {
         String testName = new Object(){}.getClass().getEnclosingMethod().getName();
         SeleniumHelper.setDoScreenPrints(true);
         holder = SeleniumHelper.getWebDriver(DriverTypes.CHROME);
-        holder.getWebDriver().navigate().to("https://example2.com/");
+        holder.getWebDriver().navigate().to("https://google.com/");
         WebDriverHolder holder2 = SeleniumHelper.getWebDriver(DriverTypes.CHROME);
         holder2.getWebDriver().navigate().to("https://www.qld.gov.au");
         SeleniumHelper.performScreenPrint(holder, testName);
@@ -125,7 +141,7 @@ public class SeleniumHelperTest {
         SeleniumHelper.performScreenPrint(holder3, testName);
         holder3.getWebDriver().navigate().to("https://www.whirlpool.net.au");
         SeleniumHelper.performScreenPrint(holder3, testName);
-        SeleniumHelper.close(holder);
+        SeleniumHelper.close(holder3);
     }
 
     @Test
@@ -133,7 +149,7 @@ public class SeleniumHelperTest {
         String testName = new Object(){}.getClass().getEnclosingMethod().getName();
         SeleniumHelper.setDoScreenPrints(true);
         holder = SeleniumHelper.getWebDriver(DriverTypes.HtmlUnitDriver);
-        holder.getWebDriver().navigate().to("https://example2.com/");
+        holder.getWebDriver().navigate().to("https://google.com/");
         SeleniumHelper.performScreenPrint(holder, testName);
         SeleniumHelper.close(holder);
     }
@@ -143,7 +159,101 @@ public class SeleniumHelperTest {
         String testName = new Object(){}.getClass().getEnclosingMethod().getName();
         SeleniumHelper.setDoScreenPrints(true);
         holder = SeleniumHelper.getWebDriver(DriverTypes.HtmlUnitDriverWithJS);
-        holder.getWebDriver().navigate().to("https://example2.com/");
+        holder.getWebDriver().navigate().to("https://www.bing.com/");
         SeleniumHelper.performScreenPrint(holder, testName);
+        SeleniumHelper.close(holder);
     }
+
+    @Test
+    public void shouldSetDownloadDirectoryForFirefoxBrowser() throws IOException {
+        String testName = new Object(){}.getClass().getEnclosingMethod().getName();
+        SeleniumHelper.setDoScreenPrints(true);
+        Path tempDownloadDirectory = Files.createTempDirectory("tempDownloads");
+        tempDownloadDirectory.toFile().deleteOnExit();
+        String downloadFilepath = tempDownloadDirectory.toFile().getAbsolutePath() + "/";
+        holder = SeleniumHelper.getWebDriver(DriverTypes.FIREFOX, downloadFilepath);
+        holder.getWebDriver().navigate().to("about:preferences");
+        assertThat(holder.getWebDriver().findElement(new By.ByXPath("//*[@id='downloadFolder']")).getAttribute("style")).containsIgnoringCase(downloadFilepath);
+        SeleniumHelper.performScreenPrint(holder, testName);
+        SeleniumHelper.close(holder);
+    }
+
+    @Test
+    public void shouldSetDownloadDirectoryForChromeBrowser() throws IOException, InterruptedException {
+        String testName = new Object(){}.getClass().getEnclosingMethod().getName();
+        SeleniumHelper.setDoScreenPrints(true);
+        // chrome://settings/downloads uses "#shadow-root" which prevents using xpath to view the download directory, so try download instead
+        Path tempDownloadDirectory = Files.createTempDirectory("tempDownloads");
+        tempDownloadDirectory.toFile().deleteOnExit();
+        String downloadFilepath = tempDownloadDirectory.toFile().getAbsolutePath() + "/";
+        String filename = "ict-dashboard-dcyjma-dataset.csv";
+        holder = SeleniumHelper.getWebDriver(DriverTypes.CHROME, downloadFilepath);
+        // Download a test CSV from dev.data.qld.gov.au: "ict-dashboard-dcyjma-dataset.csv"
+        holder.getWebDriver().navigate().to("https://dev.data.qld.gov.au/dataset/0aa564f0-32be-4aff-89af-565882fd4982/resource/0f623a2a-1ef3-4f7e-8a4c-45a4de31cef7/download/ict-dashboard-dcyjma-dataset.csv");
+        FluentWait<WebDriver> wait = new FluentWait<>(holder.getWebDriver()).withTimeout(Duration.ofSeconds(10L)).pollingEvery(Duration.ofMillis(100));
+        File downloadedFile = new File(downloadFilepath + filename);
+        wait.until(x -> downloadedFile.exists());
+        try {
+            Assertions.assertThat(downloadedFile).exists();
+        } catch (AssertionError e) {
+            Set<String> files = Stream.of(tempDownloadDirectory.toFile().listFiles())
+                    .filter(file -> !file.isDirectory())
+                    .map(File::getName)
+                    .collect(Collectors.toSet());
+            System.out.println("Could not find file, found: " + String.join(", ", files));
+            throw e;
+        }
+        downloadedFile.deleteOnExit();
+        SeleniumHelper.performScreenPrint(holder, testName);
+        SeleniumHelper.close(holder);
+    }
+
+    // Need Selenium 4 before custom download directory for Edge is implemented
+    /* @Test
+    public void shouldSetDownloadDirectoryForEdgeBrowser() throws IOException {
+        String testName = new Object(){}.getClass().getEnclosingMethod().getName();
+        SeleniumHelper.setDoScreenPrints(true);
+        Path tempDownloadDirectory = Files.createTempDirectory("tempDownloads");
+        tempDownloadDirectory.toFile().deleteOnExit();
+        String downloadFilepath = tempDownloadDirectory.toFile().getAbsolutePath() + "/";
+        try {
+            holder = SeleniumHelper.getWebDriver(DriverTypes.EDGE, downloadFilepath);
+            holder.getWebDriver().navigate().to("edge://settings/downloads");
+            assertThat(holder.getWebDriver().findElement(new By.ByXPath("//p[contains(text(), '" + downloadFilepath + "')]")).isDisplayed()).isTrue();
+            SeleniumHelper.performScreenPrint(holder, testName);
+        } catch (RuntimeException e) {
+            // Expected when not on windows
+            assertThat(e.getMessage()).isEqualTo("Have to be on windows to run Edge");
+            assertThat(e).isInstanceOf(IllegalStateException.class);
+        }
+        SeleniumHelper.close(holder);
+    } */
+
+    @Test
+    public void shouldSetDownloadDirectoryForSafariBrowser() throws IOException, InterruptedException {
+        String testName = new Object(){}.getClass().getEnclosingMethod().getName();
+        SeleniumHelper.setDoScreenPrints(true);
+        Path tempDownloadDirectory = Files.createTempDirectory("tempDownloads");
+        tempDownloadDirectory.toFile().deleteOnExit();
+        String downloadFilepath = tempDownloadDirectory.toFile().getAbsolutePath() + "/";
+        String filename = "ict-dashboard-dcyjma-dataset.csv";
+        // Not sure how safari has settings set up, so try download instead
+        try {
+            holder = SeleniumHelper.getWebDriver(DriverTypes.SAFARI, downloadFilepath);
+            // Download a test CSV from dev.data.qld.gov.au: "ict-dashboard-dcyjma-dataset.csv"
+            holder.getWebDriver().navigate().to("https://dev.data.qld.gov.au/dataset/0aa564f0-32be-4aff-89af-565882fd4982/resource/0f623a2a-1ef3-4f7e-8a4c-45a4de31cef7/download/ict-dashboard-dcyjma-dataset.csv");
+            TimeUnit.SECONDS.sleep(3);
+            File downloadedFile = new File(downloadFilepath + filename);
+            Assertions.assertThat(downloadedFile).exists();
+            downloadedFile.deleteOnExit();
+            SeleniumHelper.performScreenPrint(holder, testName);
+            SeleniumHelper.close(holder);
+        } catch (RuntimeException e) {
+            // Expected when not on mac
+            assertThat(e.getMessage()).isEqualTo("Have to be on Mac to run Safari");
+            assertThat(e).isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    // Custom download directories haven't beeen implemented for HtmlUnitBrowser and HtmlUnitWithJsBrowser
 }


### PR DESCRIPTION
[[QOLDEV-22] Introduce custom download folder and ensure it works in headless.

* Fix proxy, chrome prefs, use new headless setting for chrome, use FluentWait
* Set temporary directory for downloads on the runner
* Reuse browser if download directory is the same, cleanup HtmlUnitDriver settings
* Correct holder close in test and tweak name of test
* Fixing directory settings and adding tests
* Cleanup unneeded dependency suppressions and cleanup test
* Update dependency-check version
* Undo addition of last SeleniumHelper.close()
* Update dependencies and suppressions, and change test website from example2.com to google.com

[QOLDEV-22]: https://ssq-qol.atlassian.net/browse/QOLDEV-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ